### PR TITLE
Update shooting-star-tracking to v1.1

### DIFF
--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
-commit=8b4235ce80190707a46bb1cd2ada0a5e59068830
+commit=9be6a7f18edc5241278858ca3beae0dae9722640


### PR DESCRIPTION
Tooltips for the location field,
Correctly read time remaining when on boundary between 59 mins to 1 hour